### PR TITLE
Update index.mdx - Incorrect Env Name accessing in Lambda function

### DIFF
--- a/src/pages/[platform]/build-a-backend/add-aws-services/custom-resources/index.mdx
+++ b/src/pages/[platform]/build-a-backend/add-aws-services/custom-resources/index.mdx
@@ -170,7 +170,7 @@ const client = new SNSClient({ region: process.env.AWS_REGION });
 export const handler: Handler<Message, void> = async (event) => {
   const { subject, body, recipient } = event;
   const command = new PublishCommand({
-    TopicArn: process.env.TOPIC_ARN,
+    TopicArn: process.env.SNS_TOPIC_ARN,
     Message: JSON.stringify({
       subject,
       body,


### PR DESCRIPTION
#### Description of changes:

Publisher Lambda function code is accessing incorrect env variable name. In the backend.ts it is defined as SNS_TOPIC_ARN whereas in function code it is being accessed as TOPIC_ARN.

#### Related GitHub issue #, if available:

### Instructions

**If this PR should not be merged upon approval for any reason, please submit as a DRAFT**

Which product(s) are affected by this PR (if applicable)?
- [ ] amplify-cli
- [ ] amplify-ui
- [ ] amplify-studio
- [ ] amplify-hosting
- [x] amplify-libraries

Which platform(s) are affected by this PR (if applicable)?
- [ ] JS
- [ ] Swift
- [ ] Android
- [ ] Flutter
- [ ] React Native

**Please add the product(s)/platform(s) affected to the PR title**

#### Checks

- [ ] Does this PR conform to [the styleguide](https://github.com/aws-amplify/docs/blob/main/STYLEGUIDE.md)?

- [ ] Does this PR include filetypes other than markdown or images? Please add or update unit tests accordingly.

- [ ] Are any files being deleted with this PR? If so, have the needed redirects been created?

- [ ] Are all links in MDX files using the MDX link syntax rather than HTML link syntax? <br /> 
      _ref: MDX: `[link](https://docs.amplify.aws/)` 
            HTML: `<a href="https://docs.amplify.aws/">link</a>`_

### When this PR is ready to merge, please check the box below
- [ ] Ready to merge

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
